### PR TITLE
Improve error checking and reporting in Eve code generation.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,6 +19,7 @@ pip-tools>=5.1
 pre-commit>=2.2
 pytest>=5.4
 pytest-cov>=2.8
+pytest-lazy-fixture>=0.6.3
 #pytype
 seed-isort-config>=2.1.0
 setuptools>=40.8.0

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -69,7 +69,7 @@ except ImportError:
 
 SourceFormatter = Callable[[str], str]
 
-#: Global dict storing registered formatters
+#: Global dict storing registered formatters.
 SOURCE_FORMATTERS: Dict[str, SourceFormatter] = {}
 
 
@@ -669,13 +669,13 @@ class TemplatedGenerator(NodeVisitor):
                         **kwargs,
                     )
                 except TemplateRenderingError as e:
-                    # Add extra information to the raised exception
-                    message = (
+                    # Raise a new exception with extra information keeping the original cause
+                    raise TemplateRenderingError(
                         f"Error in '{key}' template when rendering node '{node}'.\n"
-                        + getattr(e, "message", str(e))
-                    )
-
-                    raise TemplateRenderingError(message, **e.info, node=node) from e
+                        + getattr(e, "message", str(e)),
+                        **e.info,
+                        node=node,
+                    ) from e.__cause__
 
         elif isinstance(node, (collections.abc.Sequence, collections.abc.Set)) and not isinstance(
             node, type_definitions.ATOMIC_COLLECTION_TYPES

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -418,7 +418,7 @@ class BaseTemplate(Template):
     def __str__(self) -> str:
         result = f"<{type(self).__qualname__}: '{self.definition}'>"
         if self.definition_loc:
-            result += f" defined at {self.definition_loc[0]}:{self.definition_loc[1]}"
+            result += f" created at {self.definition_loc[0]}:{self.definition_loc[1]}"
         return result
 
 
@@ -439,7 +439,7 @@ class FormatTemplate(BaseTemplate):
         except Exception as e:
             message = f"<{type(self).__name__}: '{self.definition}'>"
             if self.definition_loc:
-                message += f" (defined at {self.definition_loc[0]}:{self.definition_loc[1]})"
+                message += f" (created at {self.definition_loc[0]}:{self.definition_loc[1]})"
             message += " rendering error."
 
             raise TemplateRenderingError(message, template=self) from e
@@ -463,10 +463,10 @@ class StringTemplate(BaseTemplate):
         except Exception as e:
             message = f"<{type(self).__name__}>"
             if self.definition_loc:
-                message += f" (defined at {self.definition_loc[0]}:{self.definition_loc[1]})"
+                message += f" (created at {self.definition_loc[0]}:{self.definition_loc[1]})"
             try:
                 loc_info = re.search(r"line (\d+), col (\d+)", str(e))
-                message += f" rendering error around line: {loc_info[1]}, column {loc_info[2]}."  # type: ignore
+                message += f" rendering error at template line: {loc_info[1]}, column {loc_info[2]}."  # type: ignore
             except Exception:
                 message += " rendering error."
 
@@ -490,7 +490,7 @@ class JinjaTemplate(BaseTemplate):
         except Exception as e:
             message = "Error in JinjaTemplate"
             if self.definition_loc:
-                message += f" defined at {self.definition_loc[0]}:{self.definition_loc[1]}"
+                message += f" created at {self.definition_loc[0]}:{self.definition_loc[1]}"
                 try:
                     if hasattr(e, "lineno"):
                         message += f" (error likely around line: {e.lineno})"  # type: ignore  # assume Jinja exception
@@ -505,9 +505,9 @@ class JinjaTemplate(BaseTemplate):
         except Exception as e:
             message = f"<{type(self).__name__}>"
             if self.definition_loc:
-                message += f" (defined at {self.definition_loc[0]}:{self.definition_loc[1]})"
+                message += f" (created at {self.definition_loc[0]}:{self.definition_loc[1]})"
             try:
-                message += f" rendering error around line: {e.lineno}."  # type: ignore  # assume Jinja exception
+                message += f" rendering error at template line: {e.lineno}."  # type: ignore  # assume Jinja exception
             except Exception:
                 message += " rendering error."
 
@@ -529,7 +529,7 @@ class MakoTemplate(BaseTemplate):
         except Exception as e:
             message = "Error in MakoTemplate"
             if self.definition_loc:
-                message += f" defined at {self.definition_loc[0]}:{self.definition_loc[1]}"
+                message += f" created at {self.definition_loc[0]}:{self.definition_loc[1]}"
                 try:
                     message += f" (error likely around line {e.lineno}, column: {getattr(e, 'pos', '?')})"  # type: ignore  # assume Mako exception
                 except Exception:
@@ -545,9 +545,9 @@ class MakoTemplate(BaseTemplate):
         except Exception as e:
             message = f"<{type(self).__name__}>"
             if self.definition_loc:
-                message += f" (defined at {self.definition_loc[0]}:{self.definition_loc[1]})"
+                message += f" (created at {self.definition_loc[0]}:{self.definition_loc[1]})"
             try:
-                message += f" rendering error around line: {e.lineno}, column: {getattr(e, 'pos', '?')}"  # type: ignore  # assume Mako exception
+                message += f" rendering error at template line: {e.lineno}, column: {getattr(e, 'pos', '?')}"  # type: ignore  # assume Mako exception
             except Exception:
                 message += " rendering error."
 

--- a/src/eve/exceptions.py
+++ b/src/eve/exceptions.py
@@ -23,7 +23,7 @@ class EveError:
     message_template = "Generic Eve error (info: {info}) "
 
     def __init__(self, message: str = None, **kwargs: Any) -> None:
-        super().__init__(**kwargs)  # type: ignore  # mypy issue 4335
+        super().__init__()
         self.message = message
         self.info = kwargs
 

--- a/src/eve/exceptions.py
+++ b/src/eve/exceptions.py
@@ -24,7 +24,9 @@ class EveError:
 
     Notes:
         This base class has to be always inherited together with a standard
-    exception.
+    exception, and thus it should not be used as direct superclass
+    for custom exceptions. Inherit directly from :class:`EveTypeError`,
+    :class:`EveTypeError`... instead.
 
     """
 
@@ -39,12 +41,18 @@ class EveError:
 
 
 class EveTypeError(EveError, TypeError):
+    """Base class for Eve-specific type errors."""
+
     message_template = "Invalid or unexpected type (info: {info})"
 
 
 class EveValueError(EveError, ValueError):
+    """Base class for Eve-specific value errors."""
+
     message_template = "Invalid value (info: {info})"
 
 
 class EveRuntimeError(EveError, RuntimeError):
+    """Base class for Eve-specific run-time errors."""
+
     message_template = "Runtime error (info: {info})"

--- a/src/eve/exceptions.py
+++ b/src/eve/exceptions.py
@@ -26,33 +26,36 @@ class EveError:
         This base class has to be always inherited together with a standard
     exception, and thus it should not be used as direct superclass
     for custom exceptions. Inherit directly from :class:`EveTypeError`,
-    :class:`EveTypeError`... instead.
+    :class:`EveTypeError`, etc. instead.
 
     """
 
-    message_template = "Generic Eve error (info: {info}) "
+    message_template = "Generic Eve error [{info}]"
     info: Dict[str, Any]
 
     def __init__(self, message: str = None, **kwargs: Any) -> None:
-        super().__init__(  # type: ignore  # when inherited together with another exception the super() call works
-            message or type(self).message_template.format(**self.info, info=self.info)
-        )
         self.info = kwargs
+        super().__init__(  # type: ignore  # super() call works as expected when using multiple inheritance
+            message
+            or type(self).message_template.format(
+                **self.info, info=", ".join(f"{key}={value}" for key, value in self.info.items())
+            )
+        )
 
 
 class EveTypeError(EveError, TypeError):
     """Base class for Eve-specific type errors."""
 
-    message_template = "Invalid or unexpected type (info: {info})"
+    message_template = "Invalid or unexpected type [{info}]"
 
 
 class EveValueError(EveError, ValueError):
     """Base class for Eve-specific value errors."""
 
-    message_template = "Invalid value (info: {info})"
+    message_template = "Invalid value [{info}]"
 
 
 class EveRuntimeError(EveError, RuntimeError):
     """Base class for Eve-specific run-time errors."""
 
-    message_template = "Runtime error (info: {info})"
+    message_template = "Runtime error [{info}]"

--- a/src/eve/exceptions.py
+++ b/src/eve/exceptions.py
@@ -16,20 +16,26 @@
 
 """Definitions of specific Eve exceptions."""
 
-from .typingx import Any
+from .typingx import Any, Dict
 
 
 class EveError:
+    """Base class for Eve-specific exceptions.
+
+    Notes:
+        This base class has to be always inherited together with a standard
+    exception.
+
+    """
+
     message_template = "Generic Eve error (info: {info}) "
+    info: Dict[str, Any]
 
     def __init__(self, message: str = None, **kwargs: Any) -> None:
-        super().__init__()
-        self.message = message
+        super().__init__(  # type: ignore  # when inherited together with another exception the super() call works
+            message or type(self).message_template.format(**self.info, info=self.info)
+        )
         self.info = kwargs
-
-    def __str__(self) -> str:
-        message = self.message or self.__class__.message_template
-        return message.format(**self.info, info=self.info)
 
 
 class EveTypeError(EveError, TypeError):

--- a/src/eve/typingx.py
+++ b/src/eve/typingx.py
@@ -17,19 +17,31 @@
 """Python version independent typings."""
 
 # flake8: noqa
-from typing import *  # isort:skip
 
-import sys  # isort:skip
+from typing import *
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Final, Literal, Protocol, TypedDict, runtime_checkable
-
-del sys
 
 T = TypeVar("T")
 FrozenList = Tuple[T, ...]
 
-
 AnyCallable = Callable[..., Any]
 AnyNoneCallable = Callable[..., None]
 AnyNoArgCallable = Callable[[], Any]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "__path__":
+        # __path__ can only be defined for packages
+        raise AttributeError(f"module '{name}' has no attribute '__path__'")
+
+    try:
+        import typing
+
+        return getattr(typing, name)
+    except AttributeError:
+        try:
+            import typing_extensions
+
+            return getattr(typing_extensions, name)
+        except AttributeError:
+            raise ImportError(f"cannot import name '{name}' from 'typing' or 'typing_extensions'")

--- a/src/eve/typingx.py
+++ b/src/eve/typingx.py
@@ -17,8 +17,17 @@
 """Python version independent typings."""
 
 # flake8: noqa
+from typing import *  # isort:skip
 
+import sys  # isort:skip
 from typing import *
+from typing import IO, BinaryIO, TextIO
+
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Final, Literal, Protocol, TypedDict, runtime_checkable
+
+del sys
 
 
 T = TypeVar("T")
@@ -27,21 +36,3 @@ FrozenList = Tuple[T, ...]
 AnyCallable = Callable[..., Any]
 AnyNoneCallable = Callable[..., None]
 AnyNoArgCallable = Callable[[], Any]
-
-
-def __getattr__(name: str) -> Any:
-    if name == "__path__":
-        # __path__ can only be defined for packages
-        raise AttributeError(f"module '{name}' has no attribute '__path__'")
-
-    try:
-        import typing
-
-        return getattr(typing, name)
-    except AttributeError:
-        try:
-            import typing_extensions
-
-            return getattr(typing_extensions, name)
-        except AttributeError:
-            raise ImportError(f"cannot import name '{name}' from 'typing' or 'typing_extensions'")

--- a/tests/tests_eve/unit_tests/test_codegen.py
+++ b/tests/tests_eve/unit_tests/test_codegen.py
@@ -39,7 +39,7 @@ def test_name(name_with_cases):  # noqa: F811  # pytest fixture not detected
 
 # -- Template tests --
 def fmt_tpl_maker(skeleton, keys):
-    transformed_keys = {k: "{{{}}}".format(k) for k in keys}
+    transformed_keys = {k: "{{{key}}}".format(key=k) for k in keys}
     return eve.codegen.FormatTemplate(skeleton.format(**transformed_keys))
 
 

--- a/tests/tests_eve/unit_tests/test_exceptions.py
+++ b/tests/tests_eve/unit_tests/test_exceptions.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Eve Toolchain - GT4Py Project - GridTools Framework
+#
+# Copyright (c) 2020, CSCS - Swiss National Supercomputing Center, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from __future__ import annotations
+
+import pytest
+
+from eve import exceptions
+
+
+def test_exception_types():
+    with pytest.raises(TypeError):
+        raise exceptions.EveTypeError()
+
+    with pytest.raises(ValueError):
+        raise exceptions.EveValueError()
+
+    with pytest.raises(RuntimeError):
+        raise exceptions.EveRuntimeError()
+
+
+def test_default_exception_message():
+    with pytest.raises(TypeError, match="my_data=23, your_data=42"):
+        raise exceptions.EveTypeError(my_data=23, your_data=42)
+
+    with pytest.raises(ValueError, match="my_data=23, your_data=42"):
+        raise exceptions.EveValueError(my_data=23, your_data=42)
+
+    with pytest.raises(RuntimeError, match="my_data=23, your_data=42"):
+        raise exceptions.EveRuntimeError(my_data=23, your_data=42)
+
+
+def test_custom_exception_message():
+    with pytest.raises(TypeError, match="custom message"):
+        raise exceptions.EveTypeError("This is a custom message", my_data=23, your_data=42)
+
+    with pytest.raises(ValueError, match="custom message"):
+        raise exceptions.EveValueError("This is a custom message", my_data=23, your_data=42)
+
+    with pytest.raises(RuntimeError, match="custom message"):
+        raise exceptions.EveRuntimeError("This is a custom message", my_data=23, your_data=42)

--- a/tests/tests_eve/unit_tests/test_utils.py
+++ b/tests/tests_eve/unit_tests/test_utils.py
@@ -17,10 +17,8 @@
 import copy
 import dataclasses
 import hashlib
-import string
 from typing import Any
 
-import numpy as np
 import pydantic
 import pytest
 
@@ -221,62 +219,6 @@ def test_case_style_converter(name_with_cases):
             assert [w.lower() for w in CaseStyleConverter.split(cased_string, case)] == [
                 w.lower() for w in words
             ]
-
-
-# -- FStringFormatter tests --
-@pytest.fixture(params=[(), (0.12345, -1.12345, 2.12345, -3.12345, 4.12345), np.random.rand(5)])
-def data_collection(request):
-    yield request.param
-
-
-@pytest.fixture(
-    params=[
-        "abc {a['x']} def",
-        "result={foo()}",
-        "{fn(lst,2)} {fn(lst,3)}",
-        "{fn(lst,2)} {fn(lst,3)}",
-        "{';'.join(str((i, d)) for i, d in enumerate(data_collection))}",
-    ]
-)
-def fstr_cases(request, data_collection):
-    def foo():
-        return "FOO_VALUE"
-
-    def fn(ll, incr):
-        result = ll[0]
-        ll[0] += incr
-        return result
-
-    context = dict(a={"x": "(X)"}, foo=foo, fn=fn, lst=[0], data_collection=data_collection)
-    expected = eval(f"""(f"{request.param}")""", {}, context)
-    context["lst"] = [0]  # reset state
-
-    yield (request.param, context, expected)
-
-
-class TestXStringFormatter:
-    def test_without_extras(self, data_collection):
-        fmt = eve.utils.XStringFormatter()
-        std_fmt = string.Formatter()
-
-        assert fmt.format("aA") == std_fmt.format("aA")
-        assert fmt.format("a{}A", 0) == std_fmt.format("a{}A", 0)
-        assert fmt.format("a{:*^5}A", 0) == std_fmt.format("a{:*^5}A", 0)
-        assert fmt.format("a{:*^5.3}A", 0.12345) == std_fmt.format("a{:*^5.3}A", 0.12345)
-        assert fmt.format(
-            "a{:*^{width}.{precision}}A", 0.12345, width=6, precision=3
-        ) == std_fmt.format("a{:*^{width}.{precision}}A", 0.12345, width=6, precision=3)
-        assert fmt.format("{data}", data=data_collection) == std_fmt.format(
-            "{data}", data=data_collection
-        )
-        assert fmt.format("{data:}", data=data_collection) == std_fmt.format(
-            "{data:}", data=data_collection
-        )
-
-    def test_with_expressions(self, fstr_cases):
-        fmt = eve.utils.XStringFormatter()
-
-        assert fmt.format(fstr_cases[0], **fstr_cases[1]) == fstr_cases[2]
 
 
 # -- TestUIDGenerator --


### PR DESCRIPTION
Improve error checking and reporting in Eve code generation.

Main changes:
    - Raising custom exceptions in template rendering errors with proper information
    - Raising custom exceptions in source formatting errors
    - Setting StrictUndefined jinja2 option
    - Replacing FormatTemplate implementation strategy with full support for f-string expressions
    - Converting Template into a typing.Protocol (supporting structural subtyping for Template implementations)
    - Remove obsolete utils.XStringFormatter class 